### PR TITLE
Add governance doc

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -119,7 +119,7 @@ Not every Maintainer will reach this level, and that's okay! Maintainers still h
 
 The **Organizer** role exists to resolve disputes, keep the project accountable, and break ties when needed.
 
-This is not a "leader" role&mdash;the Organizer is a facilitator and tiebreaker. The role can be held by a single person or a small group, and is filled when the need arises.
+This is not a "leader" role&mdash;the Organizer is a facilitator and tiebreaker. The role can be held by a single person and is revaluated on an annual basis.
 
 #### Responsibilities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,255 @@
+# Governance
+
+This document outlines the roles and processes which govern all Bombshell projects. As a volunteer-based, community-run open source project, we value transparency in the pursuit of building a high trust organization.
+
+> [!IMPORTANT]
+> All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md). CoC violations are handled according to our [Moderation](#moderation) process.
+
+## Get Involved
+
+**Anything that supports the Bombshell community is a valuable contribution!**
+
+Every contribution is meaningful. Whether you are writing code, fixing a typo, posting in [Discord](https://bomb.sh/chat), sharing on social media, reviewing a pull request, or writing about Bombshell on your personal blog&mdash;no contribution is too small!
+
+Everyone can become a Bombshell contributor! We strive to recognize all contributions that improve the health of our community, regardless of a contributor's age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Contributor Roles
+
+Each level of contribution to the Bombshell community comes with a specific set of privileges and responsibilites. These levels are referred to as **Contributor Roles**.
+
+Roles are available to **all members** of the Bombshell community and are not limited to "people who write code."
+
+The two most important things we look for in a contributor are:
+
+- **Being present**&mdash;the fact that you've decided to spend your valuable time contributing to our project is amazing! Thank you for being in this with us.
+
+- **Being kind**&mdash;you go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) to foster welcoming, healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our immediate ecosystem (for example, on social media.)
+
+Contributor roles are a _recognition of contributions you have already made_ to our community. If you ever wish to resign from your current role at any time, you are invited to do so&mdash;no questions asked and no hard feelings. See [Resignation](#resignation-alumni) for more information.
+
+In extreme cases, contributors who violate our [Code of Conduct](CODE_OF_CONDUCT.md) may have their role revoked at the discretion of the core maintainers.
+
+### Contributor
+
+Have you done something to contribute to the health, success, or growth of Bombshell? **Congratulations, you are now officially recognized as a Bombshell Contributor! 🎉**
+
+#### Examples of contributions
+
+- **GitHub:** Submitting a merged pull request.
+- **GitHub:** Filing a detailed bug report.
+- **GitHub:** Updating documentation to fix a typo.
+- Helping people on GitHub, Discord, etc.
+- Answering questions on Stack Overflow, Bluesky, etc.
+- Blogging, Vlogging, Podcasting, and Livestreaming about Bombshell.
+- **This list is incomplete!** Similar contributions are also recognized.
+
+#### Privileges
+
+- New role on [Discord](https://bomb.sh/chat): `@contributor`
+- New color on Discord: **green**
+- Early access to new projects, ocassional swag drops, and more!
+
+#### Responsibilities
+
+This role does not come with any additional responsibilities or commitment, but we hope you stick around and keep participating in our community!
+
+#### Nomination
+
+TODO
+<!-- You may self-nominate by running the `/contribute` command in any Discord channel. If you do this, please include a link or description of your contribution so that people can recognize you for the contribution.
+
+You may also be granted this role automatically if you are active and helpful on Discord.
+
+If you're interested in reaching the next level and becoming a **Maintainer**, you can explore some of those responsibilities in the [next section](#level-2-l2---maintainer).
+-->
+
+### Maintainer
+
+The **Maintainer** role is available to contributors who want to join the team and take part in the long-term maintenance and growth of Bombshell.
+
+<!--
+The Maintainer role is critical to the long-term health of Astro. Maintainers act as the first line of defense when it comes to new issues, pull requests and Discord activity. Maintainers are most likely the first people that a user will interact with on Discord or GitHub.
+
+**Maintainers are not required to write code!** Some Maintainers spend most of their time inside of Discord, maintaining a healthy community there. Others work on technical documentation, support, or design.
+
+**A Maintainer has moderation privileges!** All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
+
+#### Recognized Contributions
+
+There is no strict minimum number of contributions needed to reach this level, as long as you can show **sustained** involvement over some amount of time (at least a few months).
+
+- **GitHub:** Submitting multiple non-trivial pull requests and RFCs
+- **GitHub:** Reviewing multiple non-trivial pull requests and RFCs
+- **Discord:** Supporting users in Discord, especially in the #support channel
+- **Discord:** Active participation in RFC calls and other events
+- **GitHub + Discord:** Triaging and confirming user issues
+- This list is incomplete! Similar contributions are also recognized.
+
+#### Privileges
+
+- All privileges of the [Contributor role](#level-1---contributor), plus...
+- Invitation to the `@maintainer` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#maintainers` channel on Discord.
+- Invitation to the `withastro` organization on GitHub.
+- Invitation to the `@maintainers` team on GitHub.
+- New name color on Discord: **blue**.
+- Ability to moderate Discord to remove spam, harmful speech, etc.
+- Ability to join the `@mods` role on Discord (optional, opt-in).
+- Ability to push branches directly to the `withastro` GitHub organization (personal forks no longer needed).
+- Ability to review GitHub PRs.
+- Ability to merge _some_ GitHub PRs.
+- Ability to vote on _some_ initiatives (see [Voting](#voting) below).
+
+#### Responsibilities
+
+- Participate in the project as a team player.
+- Bring a friendly, welcoming voice to the Astro community.
+- Be active on Discord, especially in the #support channel.
+- Triage new issues.
+- Review pull requests.
+- Merge some, non-trivial community pull requests.
+- Merge your own pull requests (once reviewed and approved).
+
+#### Nomination
+
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer.
+- You can be nominated by any existing Maintainer (L2 or above).
+- Once nominated, there will be a vote by existing Maintainers.
+- See [vote rules & requirements](#voting) for info on how the vote works.
+
+-->
+
+### Core
+<!--
+The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/or actively posting on Discord.
+
+Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges within our community.
+
+#### Privileges
+
+- All privileges of the [Maintainer role](#level-2---maintainer), plus...
+- `@core` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **yellow**.
+- Invitation to the private `#core` channel on Discord.
+- Invitation to the `core` team on GitHub.
+- Ability to vote on most initiatives (see [Voting](#voting) below).
+
+#### Responsibilities
+
+- All of the responsibilities of L2, including...
+- Ownership over specific part(s) of the project.
+- Ownership over the long-term health and success of Astro.
+- Leadership as a role-model to other maintainers and community members.
+
+#### Nomination
+
+- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Core member.
+- You can be nominated by any existing Core member (L3 or above).
+- Once nominated, there will be a vote by existing Core members.
+- See [vote rules & requirements](#voting) for info on how the vote works.
+
+-->
+
+## Other Roles
+
+### Project Teams
+
+Besides our contributor levels described above, there are additional roles and teams available that community members are welcome to join. Roles are a great way to organize around different projects and initiatives in our community. For example:
+
+- `@team-docs` runs the `#docs` channel and organizes the growth and development of our documentation.
+
+Many of these team roles can be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
+
+### Moderator
+
+**Moderator** is a special role available to Maintainers+. While all maintainers are granted permissions to moderate for bad behavior across our community, a Moderator actively takes on this the responsibility. For example, a community member may ping moderators (via the `@mods` role) to resolve spam posts or Code of Conduct violations.
+
+Trivial tasks (like removing spam) can be acted on unilaterally by a Moderator. Other non-trivial tasks (like assisting with or resolving a Code of Conduct violation) should involve the entire Moderator team (and in some cases, the rest of core).
+
+#### Privileges
+
+- `@mods` role on [Discord](https://astro.build/chat)
+- Invitation to the private `#moderators` channel on Discord
+
+#### Nomination
+
+Any Maintainer (L2 and above) can self-nominate by messaging the maintainers on Discord.
+
+### Alumni
+
+**Alumni** is a special designation for Maintainers+ who have stepped away from the project and no longer contribute regularly. See [Retiring a Role](#retiring-a-role-alumni) below for more information.
+
+TODO
+<!-- 
+#### Privileges
+
+- `@alumni` role on [Discord](https://astro.build/chat)
+- New name color on Discord: **light blue**.
+- Invitation to the `alumni` team on GitHub. -->
+
+<!-- ## Retiring a Role (Alumni)
+
+Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. Moving on from a project is a natural and well-understood part of any open source community, and we celebrate it! -->
+<!-- 
+**Alumni** is a special designation and role for any person who was once an active maintainer (L2 or above) but is now no longer actively involved. By retiring and joining Alumni you trade-in your current set of roles, privileges, and responsibilities for a new, special Alumni role (which comes with its own set of Privileges, as described above).
+
+As a Maintainer (L2 or above) you can retire your role at any time by pinging the project Steward and requesting Alumni status. You can initiate this action yourself if you know ahead-of-time that you need to step away from the project.
+
+If you are not actively contributing to Astro’s repositories or the Astro community for longer than six months, the project Steward may proactively retire your role, designate you as a project alumnus, and notify you of the change.
+
+As an Alumni member, you are still a part of the Astro community and can continue to be a part of our Discord, GitHub, and anywhere else. You may also request to have your old roles reinstated at any time through the normal nomination & voting process for that role.
+
+Rejoining the project as a contributor (L1 or above) will automatically remove you from the Alumni role. -->
+
+## Moderation
+
+Outlined below is the process for Code of Conduct violation reviews.
+
+TODO
+
+<!-- ### Reporting
+
+Anyone may report a violation. Violations can be reported in the following ways:
+
+- In private, via email to one or more core members.
+- In private, via direct message to a core member on Discord.
+- In public, via a GitHub comment (mentioning `@withastro/maintainers`).
+- In public, via the project Discord server (mentioning `@mods`).
+
+### Who gets involved?
+
+Each report will be assigned reviewers. These will initially be all project [stewards](#stewards).
+
+In the event of any conflict of interest - ie. stewards who are personally connected to a situation, they must immediately recuse themselves.
+
+At request of the reporter and if deemed appropriate by the reviewers, another neutral third-party may be involved in the review and decision process.
+
+### Review
+
+If a report doesn’t contain enough information, the reviewers will strive to obtain all relevant data before acting.
+
+The reviewers will then review the incident and determine, to the best of their ability:
+
+- What happened.
+- Whether this event constitutes a Code of Conduct violation.
+- Who, if anyone, was involved in the violation.
+- Whether this is an ongoing situation.
+
+The reviewers should aim to have a resolution agreed very rapidly; if not agreed within a week, they will inform the parties of the planned date.
+
+### Resolution
+
+Responses will be determined by the reviewers on the basis of the information gathered and of the potential consequences. It may include:
+
+- taking no further action
+- issuing a reprimand (private or public)
+- asking for an apology (private or public)
+- permanent ban from the GitHub org and Discord server
+- revoked contributor status
+
+-->
+
+---
+
+Inspired by [Astro](https://astro.build/governance)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -195,12 +195,18 @@ Any Maintainer (and above) can self-nominate by messaging the maintainers on Dis
 
 **Alumni** is a designation for Maintainers+ who have stepped away from the project and no longer contribute regularly.
 
+Life is fluid—it is natural that involvment shifts as priorities do. There's never any shame in stepping back, so the Alumni role exists for a few practical reasons:
+
+- **Security:** Inactive accounts with administrative access pose a risk if compromised. Moving to Alumni reduces that surface area.
+- **Funding:** When resources are allocated among contributors, it's simpler to distribute them among active members.
+- **Ecosystem health:** Keeping decision-making power with people who are actively engaged helps the project stay responsive.
+
 #### Becoming Alumni
 
 You can become Alumni in two ways:
 
 - **Voluntary:** Resign from your role at any time by notifying Core. No questions asked, no hard feelings.
-- **Inactivity:** After an extended period of inactivity, Core may reach out and offer Alumni status.
+- **Inactivity:** After an extended period of inactivity, Core will reach out. If there's no response within 30 days, the contributor moves to Alumni status. This keeps the process fair for everyone while ensuring active maintenance isn't blocked.
 
 #### Privileges
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,6 +1,6 @@
 # Governance
 
-This document outlines the roles and processes which govern all Bombshell projects. As a volunteer-based, community-run open source project, we value transparency in the pursuit of building a high trust organization.
+This document outlines the roles and processes that govern all Bombshell projects. As a volunteer-based, community-run open source project, we value transparency in the pursuit of building a high-trust organization.
 
 We bias toward clear roles and written decisions over invisible social hierarchies. Progress shouldn't depend on proximity to a small group of core contributors.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,49 +1,37 @@
 # Governance
 
-This document outlines the roles and processes that govern all Bombshell projects. As a volunteer-based, community-run open source project, we value transparency in the pursuit of building a high-trust organization.
-
-We bias toward clear roles and written decisions over invisible social hierarchies. Progress shouldn't depend on proximity to a small group of core contributors.
+This document outlines the roles and processes that govern Bombshell projects. We favor clear roles and written decisions over invisible hierarchies—progress shouldn't depend on proximity to a small group of insiders.
 
 > [!IMPORTANT]
 > All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md). CoC violations are handled according to our [Moderation](#moderation) process.
 
 ## Get Involved
 
-**Anything that supports the Bombshell community is a valuable contribution!**
-
-Every contribution is meaningful. Whether you are writing code, fixing a typo, posting in [Discord](https://bomb.sh/chat), sharing on social media, reviewing a pull request, or writing about Bombshell on your personal blog&mdash;no contribution is too small!
-
-Everyone can become a Bombshell contributor! We strive to recognize all contributions that improve the health of our community.
+Every contribution matters—writing code, fixing typos, chatting in [Discord](https://bomb.sh/chat), sharing on social media, reviewing PRs, or blogging about Bombshell. We recognize all contributions that improve our community.
 
 ## Contributor Roles
 
-Each level of contribution to the Bombshell community comes with a specific set of privileges and responsibilities. These levels are referred to as **Contributor Roles**.
+Each role comes with specific privileges and responsibilities. Roles are available to **all members**—not just people who write code.
 
-Roles are available to **all members** of the Bombshell community and are not limited to "people who write code."
+We look for two things in contributors:
 
-The two most important things we look for in a contributor are:
+- **Being present**&mdash;showing up and participating.
+- **Being kind**&mdash;fostering welcoming communication in PRs, issues, Discord, and beyond.
 
-- **Being present**&mdash;the fact that you've decided to spend your valuable time contributing to our project is amazing! Thank you for being in this with us.
+Roles recognize contributions you've already made. If you wish to step back, you can—no questions asked. See [Alumni](#alumni) for details.
 
-- **Being kind**&mdash;you go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) to foster welcoming, healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our immediate ecosystem.
-
-Contributor roles are a _recognition of contributions you have already made_ to our community. If you ever wish to resign from your current role at any time, you are invited to do so&mdash;no questions asked and no hard feelings. See [Alumni](#alumni) for more information.
-
-In extreme cases, contributors who violate our [Code of Conduct](CODE_OF_CONDUCT.md) may have their role revoked at the discretion of the Core maintainers.
+Contributors who violate our [Code of Conduct](CODE_OF_CONDUCT.md) may have their role revoked.
 
 ### Contributor
 
-Have you done something to contribute to the health, success, or growth of Bombshell? **Congratulations, you are now officially recognized as a Bombshell Contributor!**
+Have you contributed to the health, success, or growth of Bombshell? You're a Contributor.
 
 #### Examples of contributions
 
-- **GitHub:** Submitting a merged pull request.
-- **GitHub:** Filing a detailed bug report.
-- **GitHub:** Updating documentation.
-- Helping people on GitHub, Discord, etc.
-- Answering questions on Stack Overflow, BlueSky, etc.
-- Blogging, Vlogging, Podcasting, and Livestreaming about Bombshell.
-- **This list is incomplete!** Similar contributions are also recognized.
+- Submitting a merged PR, filing a detailed bug report, or updating docs
+- Helping people on GitHub, Discord, Stack Overflow, BlueSky, etc.
+- Blogging, vlogging, podcasting, or livestreaming about Bombshell
+- Similar contributions are also recognized
 
 #### Privileges
 
@@ -52,17 +40,15 @@ Have you done something to contribute to the health, success, or growth of Bombs
 
 #### Responsibilities
 
-This role does not come with any additional responsibilities or commitment, but we hope you stick around and keep participating in our community!
+None required—but we hope you stick around!
 
 #### Nomination
 
-You may self-nominate by reaching out in Discord or opening an issue. Any existing contributor can also recognize your contributions and nominate you. No formal vote is required&mdash;the barrier to entry is intentionally low.
+Self-nominate via Discord or a GitHub issue, or any existing contributor can nominate you. No vote required—the barrier is intentionally low.
 
 ### Maintainer
 
-The **Maintainer** role is available to contributors who show up consistently and want to join the team in the long-term maintenance and growth of Bombshell.
-
-Maintainers are not required to write code! Some Maintainers spend most of their time in Discord, maintaining a healthy community there. Others work on documentation, support, or design.
+**Maintainers** show up consistently and are invested in the long-term health of Bombshell. Some focus on code, others on Discord, docs, support, or design.
 
 #### Privileges
 
@@ -90,9 +76,7 @@ Maintainers are not required to write code! Some Maintainers spend most of their
 
 ### Core
 
-The **Core** role is available to Maintainers who have a larger-than-usual impact on the Bombshell project and community. Core members are seen as leaders in the project and have significant influence on project direction.
-
-Not every Maintainer will reach this level, and that's okay! Maintainers still have significant responsibility and privileges within our community.
+**Core** members are Maintainers with outsized impact and significant influence on project direction. Not every Maintainer will reach this level, and that's okay.
 
 #### Privileges
 
@@ -104,10 +88,9 @@ Not every Maintainer will reach this level, and that's okay! Maintainers still h
 
 #### Responsibilities
 
-- All of the responsibilities of Maintainer, plus...
-- Ownership over specific part(s) of the project
-- Ownership over the long-term health and success of Bombshell
-- Leadership as a role model to other maintainers and community members
+- All responsibilities of Maintainer, plus...
+- Ownership over specific areas and the long-term health of the project
+- Leadership as a role model to other contributors
 
 #### Nomination
 
@@ -172,15 +155,11 @@ Proposals are written down, discussed publicly, and resolved in the open.
 
 ### Project Teams
 
-Besides our contributor roles described above, there are additional teams available that community members are welcome to join. Teams are a great way to organize around different projects and initiatives in our community.
-
-Getting involved with a team is a great way to start contributing to Bombshell!
+Beyond contributor roles, there are teams organized around specific projects and initiatives. Joining a team is a good way to start contributing.
 
 ### Moderator
 
-**Moderator** is a special role available to Maintainers+. While all maintainers are granted permissions to moderate for bad behavior across our community, a Moderator actively takes on this responsibility.
-
-Trivial tasks (like removing spam) can be acted on unilaterally by a Moderator. Other non-trivial tasks (like assisting with or resolving a Code of Conduct violation) should involve the entire Moderator team (and in some cases, Core).
+**Moderator** is available to Maintainers+ who actively take on moderation duties. Trivial tasks (removing spam) can be handled unilaterally; non-trivial issues (CoC violations) should involve the full Moderator team or Core.
 
 #### Privileges
 
@@ -195,7 +174,7 @@ Any Maintainer (and above) can self-nominate by messaging the maintainers on Dis
 
 **Alumni** is a designation for Maintainers+ who have stepped away from the project and no longer contribute regularly.
 
-Life is fluid—it is natural that involvment shifts as priorities do. There's never any shame in stepping back, so the Alumni role exists for a few practical reasons:
+Life is fluid—it's natural that involvement shifts as priorities do. There's never any shame in stepping back, so the Alumni role exists for a few practical reasons:
 
 - **Security:** Inactive accounts with administrative access pose a risk if compromised. Moving to Alumni reduces that surface area.
 - **Funding:** When resources are allocated among contributors, it's simpler to distribute them among active members.
@@ -217,22 +196,18 @@ Alumni are always welcome to return! Rejoining as an active contributor follows 
 
 ## Moderation
 
-Outlined below is the process for Code of Conduct violation reviews.
+How Code of Conduct violations are reviewed.
 
 ### Reporting
 
-Anyone may report a violation. Violations can be reported:
+Anyone may report a violation:
 
-- In private, via email to a Core member
-- In private, via direct message to a Core member on Discord
-- In public, via a GitHub comment (mentioning `@bombshell-dev/core`)
-- In public, via the project Discord server (mentioning `@mods`)
+- **Private:** Email or DM a Core member
+- **Public:** GitHub comment (`@bombshell-dev/core`) or Discord (`@mods`)
 
 ### Review
 
-If a report doesn't contain enough information, the reviewers will strive to obtain all relevant data before acting.
-
-The reviewers will then review the incident and determine:
+If a report lacks detail, reviewers will gather more information before acting. They will determine:
 
 - What happened
 - Whether this event constitutes a Code of Conduct violation
@@ -243,7 +218,7 @@ In the event of any conflict of interest, reviewers must recuse themselves.
 
 ### Resolution
 
-Responses will be determined by the reviewers on the basis of the information gathered. They may include:
+Responses are determined based on the information gathered and may include:
 
 - Taking no further action
 - Issuing a reprimand (private or public)

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -119,7 +119,7 @@ Not every Maintainer will reach this level, and that's okay! Maintainers still h
 
 The **Organizer** role exists to resolve disputes, keep the project accountable, and break ties when needed.
 
-This is not a "leader" role&mdash;the Organizer is a facilitator and tiebreaker. The role can be held by a single person and is revaluated on an annual basis.
+This is not a "leader" role&mdash;the Organizer is a facilitator and tiebreaker. The role can be held by a single person and is reevaluated on an annual basis.
 
 #### Responsibilities
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -107,7 +107,7 @@ Not every Maintainer will reach this level, and that's okay! Maintainers still h
 - All of the responsibilities of Maintainer, plus...
 - Ownership over specific part(s) of the project
 - Ownership over the long-term health and success of Bombshell
-- Leadership as a role-model to other maintainers and community members
+- Leadership as a role model to other maintainers and community members
 
 #### Nomination
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,6 +2,8 @@
 
 This document outlines the roles and processes which govern all Bombshell projects. As a volunteer-based, community-run open source project, we value transparency in the pursuit of building a high trust organization.
 
+We bias toward clear roles and written decisions over invisible social hierarchies. Progress shouldn't depend on proximity to a small group of core contributors.
+
 > [!IMPORTANT]
 > All community members must follow the [Code of Conduct (CoC)](CODE_OF_CONDUCT.md). CoC violations are handled according to our [Moderation](#moderation) process.
 
@@ -11,12 +13,11 @@ This document outlines the roles and processes which govern all Bombshell projec
 
 Every contribution is meaningful. Whether you are writing code, fixing a typo, posting in [Discord](https://bomb.sh/chat), sharing on social media, reviewing a pull request, or writing about Bombshell on your personal blog&mdash;no contribution is too small!
 
-Everyone can become a Bombshell contributor! We strive to recognize all contributions that improve the health of our community, regardless of a contributor's age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+Everyone can become a Bombshell contributor! We strive to recognize all contributions that improve the health of our community.
 
 ## Contributor Roles
 
-Each level of contribution to the Bombshell community comes with a specific set of privileges and responsibilites. These levels are referred to as **Contributor Roles**.
+Each level of contribution to the Bombshell community comes with a specific set of privileges and responsibilities. These levels are referred to as **Contributor Roles**.
 
 Roles are available to **all members** of the Bombshell community and are not limited to "people who write code."
 
@@ -24,31 +25,30 @@ The two most important things we look for in a contributor are:
 
 - **Being present**&mdash;the fact that you've decided to spend your valuable time contributing to our project is amazing! Thank you for being in this with us.
 
-- **Being kind**&mdash;you go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) to foster welcoming, healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our immediate ecosystem (for example, on social media.)
+- **Being kind**&mdash;you go above and beyond our [Code of Conduct](CODE_OF_CONDUCT.md) to foster welcoming, healthy communication in pull requests, issue discussions, Discord conversations, and interactions outside of our immediate ecosystem.
 
-Contributor roles are a _recognition of contributions you have already made_ to our community. If you ever wish to resign from your current role at any time, you are invited to do so&mdash;no questions asked and no hard feelings. See [Resignation](#resignation-alumni) for more information.
+Contributor roles are a _recognition of contributions you have already made_ to our community. If you ever wish to resign from your current role at any time, you are invited to do so&mdash;no questions asked and no hard feelings. See [Alumni](#alumni) for more information.
 
-In extreme cases, contributors who violate our [Code of Conduct](CODE_OF_CONDUCT.md) may have their role revoked at the discretion of the core maintainers.
+In extreme cases, contributors who violate our [Code of Conduct](CODE_OF_CONDUCT.md) may have their role revoked at the discretion of the Core maintainers.
 
 ### Contributor
 
-Have you done something to contribute to the health, success, or growth of Bombshell? **Congratulations, you are now officially recognized as a Bombshell Contributor! 🎉**
+Have you done something to contribute to the health, success, or growth of Bombshell? **Congratulations, you are now officially recognized as a Bombshell Contributor!**
 
 #### Examples of contributions
 
 - **GitHub:** Submitting a merged pull request.
 - **GitHub:** Filing a detailed bug report.
-- **GitHub:** Updating documentation to fix a typo.
+- **GitHub:** Updating documentation.
 - Helping people on GitHub, Discord, etc.
-- Answering questions on Stack Overflow, Bluesky, etc.
+- Answering questions on Stack Overflow, BlueSky, etc.
 - Blogging, Vlogging, Podcasting, and Livestreaming about Bombshell.
 - **This list is incomplete!** Similar contributions are also recognized.
 
 #### Privileges
 
 - New role on [Discord](https://bomb.sh/chat): `@contributor`
-- New color on Discord: **green**
-- Early access to new projects, ocassional swag drops, and more!
+- Early access to new projects, occasional swag drops, and more!
 
 #### Responsibilities
 
@@ -56,200 +56,195 @@ This role does not come with any additional responsibilities or commitment, but 
 
 #### Nomination
 
-TODO
-<!-- You may self-nominate by running the `/contribute` command in any Discord channel. If you do this, please include a link or description of your contribution so that people can recognize you for the contribution.
-
-You may also be granted this role automatically if you are active and helpful on Discord.
-
-If you're interested in reaching the next level and becoming a **Maintainer**, you can explore some of those responsibilities in the [next section](#level-2-l2---maintainer).
--->
+You may self-nominate by reaching out in Discord or opening an issue. Any existing contributor can also recognize your contributions and nominate you. No formal vote is required&mdash;the barrier to entry is intentionally low.
 
 ### Maintainer
 
-The **Maintainer** role is available to contributors who want to join the team and take part in the long-term maintenance and growth of Bombshell.
+The **Maintainer** role is available to contributors who show up consistently and want to join the team in the long-term maintenance and growth of Bombshell.
 
-<!--
-The Maintainer role is critical to the long-term health of Astro. Maintainers act as the first line of defense when it comes to new issues, pull requests and Discord activity. Maintainers are most likely the first people that a user will interact with on Discord or GitHub.
-
-**Maintainers are not required to write code!** Some Maintainers spend most of their time inside of Discord, maintaining a healthy community there. Others work on technical documentation, support, or design.
-
-**A Maintainer has moderation privileges!** All maintainers are trusted with the ability to help moderate our Discord and GitHub communities for things like spam. There is also a special (optional, opt-in) `@mods` role open to maintainers who are also interested in helping out when a community member reaches out for moderation help.
-
-#### Recognized Contributions
-
-There is no strict minimum number of contributions needed to reach this level, as long as you can show **sustained** involvement over some amount of time (at least a few months).
-
-- **GitHub:** Submitting multiple non-trivial pull requests and RFCs
-- **GitHub:** Reviewing multiple non-trivial pull requests and RFCs
-- **Discord:** Supporting users in Discord, especially in the #support channel
-- **Discord:** Active participation in RFC calls and other events
-- **GitHub + Discord:** Triaging and confirming user issues
-- This list is incomplete! Similar contributions are also recognized.
+Maintainers are not required to write code! Some Maintainers spend most of their time in Discord, maintaining a healthy community there. Others work on documentation, support, or design.
 
 #### Privileges
 
-- All privileges of the [Contributor role](#level-1---contributor), plus...
-- Invitation to the `@maintainer` role on [Discord](https://astro.build/chat)
-- Invitation to the private `#maintainers` channel on Discord.
-- Invitation to the `withastro` organization on GitHub.
-- Invitation to the `@maintainers` team on GitHub.
-- New name color on Discord: **blue**.
+- All privileges of the [Contributor role](#contributor), plus...
+- `@maintainer` role on [Discord](https://bomb.sh/chat)
+- Access to the private `#maintainers` channel on Discord
+- Invitation to the `bombshell-dev` organization on GitHub
 - Ability to moderate Discord to remove spam, harmful speech, etc.
-- Ability to join the `@mods` role on Discord (optional, opt-in).
-- Ability to push branches directly to the `withastro` GitHub organization (personal forks no longer needed).
-- Ability to review GitHub PRs.
-- Ability to merge _some_ GitHub PRs.
-- Ability to vote on _some_ initiatives (see [Voting](#voting) below).
+- Ability to push branches directly to the organization (personal forks no longer needed)
+- Ability to review and merge GitHub PRs
+- Ability to vote on role nominations
 
 #### Responsibilities
 
-- Participate in the project as a team player.
-- Bring a friendly, welcoming voice to the Astro community.
-- Be active on Discord, especially in the #support channel.
-- Triage new issues.
-- Review pull requests.
-- Merge some, non-trivial community pull requests.
-- Merge your own pull requests (once reviewed and approved).
+- Participate in the project as a team player
+- Bring a friendly, welcoming voice to the Bombshell community
+- Triage new issues
+- Review pull requests
 
 #### Nomination
 
-- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Maintainer.
-- You can be nominated by any existing Maintainer (L2 or above).
-- Once nominated, there will be a vote by existing Maintainers.
-- See [vote rules & requirements](#voting) for info on how the vote works.
-
--->
+- To be nominated, you should already be performing some of the responsibilities of a Maintainer
+- Any existing Maintainer (or above) can nominate you
+- Once nominated, existing Maintainers vote; simple majority approves
 
 ### Core
-<!--
-The **Core** role is available to community members who have a larger-than-usual impact on the Astro project and community. They are seen as leaders in the project and are listened to by the wider Astro community, often before they have even reached this level. A Core member is recognized for contributing a significant amount of time and energy to the project through issues, pull requests, bug fixes, implementing advanced enhancements/features, and/or actively posting on Discord.
 
-Not every contributor will reach this level, and that's okay! L2 Maintainers still have significant responsibility and privileges within our community.
+The **Core** role is available to Maintainers who have a larger-than-usual impact on the Bombshell project and community. Core members are seen as leaders in the project and have significant influence on project direction.
+
+Not every Maintainer will reach this level, and that's okay! Maintainers still have significant responsibility and privileges within our community.
 
 #### Privileges
 
-- All privileges of the [Maintainer role](#level-2---maintainer), plus...
-- `@core` role on [Discord](https://astro.build/chat)
-- New name color on Discord: **yellow**.
-- Invitation to the private `#core` channel on Discord.
-- Invitation to the `core` team on GitHub.
-- Ability to vote on most initiatives (see [Voting](#voting) below).
+- All privileges of the [Maintainer role](#maintainer), plus...
+- `@core` role on [Discord](https://bomb.sh/chat)
+- Access to the private `#core` channel on Discord
+- Invitation to the `core` team on GitHub
+- Ability to vote on major initiatives and RFDs
 
 #### Responsibilities
 
-- All of the responsibilities of L2, including...
-- Ownership over specific part(s) of the project.
-- Ownership over the long-term health and success of Astro.
-- Leadership as a role-model to other maintainers and community members.
+- All of the responsibilities of Maintainer, plus...
+- Ownership over specific part(s) of the project
+- Ownership over the long-term health and success of Bombshell
+- Leadership as a role-model to other maintainers and community members
 
 #### Nomination
 
-- To be nominated, a nominee is expected to already be performing some of the responsibilities of a Core member.
-- You can be nominated by any existing Core member (L3 or above).
-- Once nominated, there will be a vote by existing Core members.
-- See [vote rules & requirements](#voting) for info on how the vote works.
+- To be nominated, you should already be performing some of the responsibilities of a Core member
+- Any existing Core member can nominate you
+- Once nominated, existing Core members vote; simple majority approves
 
--->
+### Organizer
+
+The **Organizer** role exists to resolve disputes, keep the project accountable, and break ties when needed.
+
+This is not a "leader" role&mdash;the Organizer is a facilitator and tiebreaker. The role can be held by a single person or a small group, and is filled when the need arises.
+
+#### Responsibilities
+
+- Resolve disputes that Core cannot reach consensus on
+- Break ties in votes when needed
+- Ensure governance processes are followed
+- Hold the project accountable to its stated values
+
+#### Nomination
+
+- Core members nominate an Organizer when the need arises
+- Requires consensus among Core members
+
+## Decision Making
+
+We bias toward async, written communication. Most decisions happen through:
+
+- **GitHub Issues and PRs:** For code changes, bug fixes, and smaller improvements
+- **Discord discussions:** For quick questions and informal coordination
+- **RFDs:** For significant changes that need broader input (see below)
+
+### Voting
+
+When a vote is needed (role nominations, contested decisions):
+
+- Simple majority approves for role nominations
+- Core consensus for major project decisions
+- Organizer breaks ties when consensus cannot be reached
+
+## Request For Discussion (RFD)
+
+When decisions need broader input, we use a Request For Discussion process inspired by [Oxide](https://oxide.computer/blog/rfd-1-requests-for-discussion).
+
+### When to use an RFD
+
+- Significant new features or architectural changes
+- Process or governance changes
+- Anything that benefits from written discussion and a permanent record
+
+### Process
+
+1. **Draft:** Author creates an RFD as a markdown file in the [`bombshell-dev/rfd`](https://github.com/bombshell-dev/rfd) repository and opens a PR
+2. **Discussion:** Discussion happens async in PR comments (minimum 5 business days)
+3. **Decision:** Core reviews feedback and decides; Organizer breaks ties if needed
+4. **Record:** Merged RFDs become a permanent organizational record
+
+Proposals are written down, discussed publicly, and resolved in the open.
 
 ## Other Roles
 
 ### Project Teams
 
-Besides our contributor levels described above, there are additional roles and teams available that community members are welcome to join. Roles are a great way to organize around different projects and initiatives in our community. For example:
+Besides our contributor roles described above, there are additional teams available that community members are welcome to join. Teams are a great way to organize around different projects and initiatives in our community.
 
-- `@team-docs` runs the `#docs` channel and organizes the growth and development of our documentation.
-
-Many of these team roles can be browsed and joined automatically by visiting the `#manage-roles` channel in our Discord. Getting involved with a team is a great way to start contributing to Astro!
+Getting involved with a team is a great way to start contributing to Bombshell!
 
 ### Moderator
 
-**Moderator** is a special role available to Maintainers+. While all maintainers are granted permissions to moderate for bad behavior across our community, a Moderator actively takes on this the responsibility. For example, a community member may ping moderators (via the `@mods` role) to resolve spam posts or Code of Conduct violations.
+**Moderator** is a special role available to Maintainers+. While all maintainers are granted permissions to moderate for bad behavior across our community, a Moderator actively takes on this responsibility.
 
-Trivial tasks (like removing spam) can be acted on unilaterally by a Moderator. Other non-trivial tasks (like assisting with or resolving a Code of Conduct violation) should involve the entire Moderator team (and in some cases, the rest of core).
+Trivial tasks (like removing spam) can be acted on unilaterally by a Moderator. Other non-trivial tasks (like assisting with or resolving a Code of Conduct violation) should involve the entire Moderator team (and in some cases, Core).
 
 #### Privileges
 
-- `@mods` role on [Discord](https://astro.build/chat)
-- Invitation to the private `#moderators` channel on Discord
+- `@mods` role on [Discord](https://bomb.sh/chat)
+- Access to the private `#moderators` channel on Discord
 
 #### Nomination
 
-Any Maintainer (L2 and above) can self-nominate by messaging the maintainers on Discord.
+Any Maintainer (and above) can self-nominate by messaging the maintainers on Discord.
 
 ### Alumni
 
-**Alumni** is a special designation for Maintainers+ who have stepped away from the project and no longer contribute regularly. See [Retiring a Role](#retiring-a-role-alumni) below for more information.
+**Alumni** is a designation for Maintainers+ who have stepped away from the project and no longer contribute regularly.
 
-TODO
-<!-- 
+#### Becoming Alumni
+
+You can become Alumni in two ways:
+
+- **Voluntary:** Resign from your role at any time by notifying Core. No questions asked, no hard feelings.
+- **Inactivity:** After an extended period of inactivity, Core may reach out and offer Alumni status.
+
 #### Privileges
 
-- `@alumni` role on [Discord](https://astro.build/chat)
-- New name color on Discord: **light blue**.
-- Invitation to the `alumni` team on GitHub. -->
+- `@alumni` role on [Discord](https://bomb.sh/chat)
+- You remain part of the Bombshell community
 
-<!-- ## Retiring a Role (Alumni)
-
-Contributor roles are granted for as long as the person wishes to engage with the project. However, over time an active community member may choose to step away from the Astro project to work on other things. Moving on from a project is a natural and well-understood part of any open source community, and we celebrate it! -->
-<!-- 
-**Alumni** is a special designation and role for any person who was once an active maintainer (L2 or above) but is now no longer actively involved. By retiring and joining Alumni you trade-in your current set of roles, privileges, and responsibilities for a new, special Alumni role (which comes with its own set of Privileges, as described above).
-
-As a Maintainer (L2 or above) you can retire your role at any time by pinging the project Steward and requesting Alumni status. You can initiate this action yourself if you know ahead-of-time that you need to step away from the project.
-
-If you are not actively contributing to Astro’s repositories or the Astro community for longer than six months, the project Steward may proactively retire your role, designate you as a project alumnus, and notify you of the change.
-
-As an Alumni member, you are still a part of the Astro community and can continue to be a part of our Discord, GitHub, and anywhere else. You may also request to have your old roles reinstated at any time through the normal nomination & voting process for that role.
-
-Rejoining the project as a contributor (L1 or above) will automatically remove you from the Alumni role. -->
+Alumni are always welcome to return! Rejoining as an active contributor follows the normal nomination process for the relevant role.
 
 ## Moderation
 
 Outlined below is the process for Code of Conduct violation reviews.
 
-TODO
+### Reporting
 
-<!-- ### Reporting
+Anyone may report a violation. Violations can be reported:
 
-Anyone may report a violation. Violations can be reported in the following ways:
-
-- In private, via email to one or more core members.
-- In private, via direct message to a core member on Discord.
-- In public, via a GitHub comment (mentioning `@withastro/maintainers`).
-- In public, via the project Discord server (mentioning `@mods`).
-
-### Who gets involved?
-
-Each report will be assigned reviewers. These will initially be all project [stewards](#stewards).
-
-In the event of any conflict of interest - ie. stewards who are personally connected to a situation, they must immediately recuse themselves.
-
-At request of the reporter and if deemed appropriate by the reviewers, another neutral third-party may be involved in the review and decision process.
+- In private, via email to a Core member
+- In private, via direct message to a Core member on Discord
+- In public, via a GitHub comment (mentioning `@bombshell-dev/core`)
+- In public, via the project Discord server (mentioning `@mods`)
 
 ### Review
 
-If a report doesn’t contain enough information, the reviewers will strive to obtain all relevant data before acting.
+If a report doesn't contain enough information, the reviewers will strive to obtain all relevant data before acting.
 
-The reviewers will then review the incident and determine, to the best of their ability:
+The reviewers will then review the incident and determine:
 
-- What happened.
-- Whether this event constitutes a Code of Conduct violation.
-- Who, if anyone, was involved in the violation.
-- Whether this is an ongoing situation.
+- What happened
+- Whether this event constitutes a Code of Conduct violation
+- Who, if anyone, was involved in the violation
+- Whether this is an ongoing situation
 
-The reviewers should aim to have a resolution agreed very rapidly; if not agreed within a week, they will inform the parties of the planned date.
+In the event of any conflict of interest, reviewers must recuse themselves.
 
 ### Resolution
 
-Responses will be determined by the reviewers on the basis of the information gathered and of the potential consequences. It may include:
+Responses will be determined by the reviewers on the basis of the information gathered. They may include:
 
-- taking no further action
-- issuing a reprimand (private or public)
-- asking for an apology (private or public)
-- permanent ban from the GitHub org and Discord server
-- revoked contributor status
-
--->
+- Taking no further action
+- Issuing a reprimand (private or public)
+- Asking for an apology (private or public)
+- Permanent ban from the GitHub org and Discord server
+- Revoked contributor status
 
 ---
 
-Inspired by [Astro](https://astro.build/governance)
+Inspired by [Astro](https://github.com/withastro/.github/blob/main/GOVERNANCE.md) and [Oxide](https://oxide.computer/blog/rfd-1-requests-for-discussion)


### PR DESCRIPTION
The [`GOVERNANCE.md` document](https://github.com/bombshell-dev/.github/blob/feat/governance/GOVERNANCE.md) outlines the roles and processes which govern all Bombshell projects. As a volunteer-based, community-run open source project, we value transparency in the pursuit of building a high trust organization.

We bias toward clear roles and written decisions over invisible social hierarchies. Progress shouldn't depend on proximity to a small group of core contributors.